### PR TITLE
Add setting to allow story point mods

### DIFF
--- a/mod_info.json
+++ b/mod_info.json
@@ -2,7 +2,7 @@
     "id": "progressiveSMods",
     "name": "Progressive S-Mods",
     "author": "qcwxezda",
-    "version": {"major":0, "minor":10, "patch":1},
+    "version": {"major":0, "minor":10, "patch":2},
     "dependencies": [],
     "description": "Ships gain XP during combat that can be spent to build in hull mods. Disables building in hull mods using story points.",
     "gameVersion": "0.96a-RC8",

--- a/progsmod_settings.json
+++ b/progsmod_settings.json
@@ -111,6 +111,10 @@
         "xpFractionSupport": 0.33,
     },
 
+    # Set this to true allow bulding in hullmods with both
+    # story points and buying with XP.
+    "allowStoryPointBuildIn":false,
+    
     # Set this to true in order to disable this mod's features
     # and go back to building in S-Mods with story points.
     # S-mods that have been built in with XP are not removed.

--- a/src/progsmod/data/campaign/RefitTabListenerAndScript.java
+++ b/src/progsmod/data/campaign/RefitTabListenerAndScript.java
@@ -6,6 +6,8 @@ import com.fs.starfarer.api.campaign.CampaignUIAPI;
 import com.fs.starfarer.api.campaign.CoreUITabId;
 import com.fs.starfarer.api.campaign.listeners.CoreUITabListener;
 import progsmod.plugin.ProgSMod;
+import util.SModUtils;
+
 
 public class RefitTabListenerAndScript implements CoreUITabListener, EveryFrameScript {
     private static boolean insideRefitScreen = false;
@@ -14,7 +16,9 @@ public class RefitTabListenerAndScript implements CoreUITabListener, EveryFrameS
     public void reportAboutToOpenCoreTab(CoreUITabId id, Object param) {
         if (CoreUITabId.REFIT.equals(id) && !insideRefitScreen) {
             insideRefitScreen = true;
-            ProgSMod.disableStoryPointBuildIn();
+            if (!SModUtils.Constants.ALLOW_STORY_POINT_BUILD_IN) {
+                ProgSMod.disableStoryPointBuildIn();
+            }
         }
     }
 

--- a/src/util/SModUtils.java
+++ b/src/util/SModUtils.java
@@ -117,6 +117,8 @@ public class SModUtils {
         public static boolean ALLOW_INCREASE_SMOD_LIMIT;
         /** How often the combat tracker should update ship contribution. */
         public static float COMBAT_UPDATE_INTERVAL;
+        /** Set to true to allow building in mods with story points */
+        public static boolean ALLOW_STORY_POINT_BUILD_IN;
 
         /** Set to true to disable this mod's features */
         public static boolean DISABLE_MOD;
@@ -155,6 +157,7 @@ public class SModUtils {
             RESERVE_XP_FRACTION = (float) json.getDouble("reserveXPFraction");
             IGNORE_NO_BUILD_IN = json.getBoolean("ignoreNoBuildIn");
             ALLOW_INCREASE_SMOD_LIMIT = json.getBoolean("allowIncreaseSModLimit");
+            ALLOW_STORY_POINT_BUILD_IN = json.getBoolean("allowStoryPointBuildIn");
             DISABLE_MOD = json.getBoolean("disableMod");
             JSONObject combat = json.getJSONObject("combat");
             GIVE_XP_TO_DISABLED_SHIPS = combat.getBoolean("giveXPToDisabledShips");


### PR DESCRIPTION
I added a setting to allow ship upgrades with story points, since I was almost unable to get XP for my trading/exploration fleets that I rarely bring into combat.