### PR TITLE
Prevent possible infinite recursion

### DIFF
--- a/src/progsmod/data/combat/ContributionTracker.java
+++ b/src/progsmod/data/combat/ContributionTracker.java
@@ -128,6 +128,14 @@ public class ContributionTracker extends BaseEveryFrameCombatPlugin {
         }
     }
 
+    private ShipAPI getBaseShip(ShipAPI shipWingOrModule, ShipAPI shipWingOrModulePrevious) {
+        // infinite recursion break
+        if (shipWingOrModule == shipWingOrModulePrevious) {
+            return shipWingOrModule;
+        }
+        return getBaseShip(shipWingOrModule);
+    }
+
     /** If the argument is a ship, returns that ship.
      *  If the argument is a wing, returns the wing's source ship.
      *  If the argument is a module, returns the module's base ship/station. */
@@ -141,7 +149,9 @@ public class ContributionTracker extends BaseEveryFrameCombatPlugin {
         }
         // The "ship" in question is a drone
         if (shipWingOrModule.getAIFlags().hasFlag(ShipwideAIFlags.AIFlags.DRONE_MOTHERSHIP)) {
-            ShipAPI base = getBaseShip((ShipAPI) shipWingOrModule.getAIFlags().getCustom(ShipwideAIFlags.AIFlags.DRONE_MOTHERSHIP));
+            ShipAPI base = getBaseShip(
+                    (ShipAPI) shipWingOrModule.getAIFlags().getCustom(ShipwideAIFlags.AIFlags.DRONE_MOTHERSHIP),
+                    shipWingOrModule);
             baseShipTable.put(shipWingOrModule.getId(), base);
             return base;
         }
@@ -159,7 +169,9 @@ public class ContributionTracker extends BaseEveryFrameCombatPlugin {
                 }
             }
             else {
-                base = getBaseShip(shipWingOrModule.getWing().getSourceShip());
+                base = getBaseShip(
+                        shipWingOrModule.getWing().getSourceShip(),
+                        shipWingOrModule);
             }
             baseShipTable.put(shipWingOrModule.getId(), base);
             return base; 
@@ -174,7 +186,9 @@ public class ContributionTracker extends BaseEveryFrameCombatPlugin {
                 }
             }
             else {
-                base = getBaseShip(shipWingOrModule.getParentStation());
+                base = getBaseShip(
+                        shipWingOrModule.getParentStation(),
+                        shipWingOrModule);
             }
             baseShipTable.put(shipWingOrModule.getId(), base);
             return base;


### PR DESCRIPTION
Sometimes the game crashes with log like this:

```
642286 [Thread-2] ERROR com.fs.starfarer.combat.CombatMain  - java.lang.StackOverflowError
java.lang.StackOverflowError: null
        at java.base/java.lang.String.hashCode(String.java:2411) ~[?:?]
        at java.base/java.util.HashMap.hash(HashMap.java:338) ~[?:?]
        at java.base/java.util.HashMap.getNode(HashMap.java:576) ~[?:?]
        at java.base/java.util.HashMap.get(HashMap.java:564) ~[?:?]
        at com.fs.starfarer.combat.ai.N.super.super(Unknown Source) ~[port_obf.jar:?]
        at com.fs.starfarer.combat.entities.Ship.getAIFlags(Unknown Source) ~[port_obf.jar:?]
        at progsmod.data.combat.ContributionTracker.getBaseShip(ContributionTracker.java:143) ~[?:?]
        at progsmod.data.combat.ContributionTracker.getBaseShip(ContributionTracker.java:144) ~[?:?]
        at progsmod.data.combat.ContributionTracker.getBaseShip(ContributionTracker.java:143) ~[?:?]
        at progsmod.data.combat.ContributionTracker.getBaseShip(ContributionTracker.java:144) ~[?:?]
        at progsmod.data.combat.ContributionTracker.getBaseShip(ContributionTracker.java:143) ~[?:?]
        at progsmod.data.combat.ContributionTracker.getBaseShip(ContributionTracker.java:144) ~[?:?]
```

This change should fix most of situations where it is possible.